### PR TITLE
requests-oauthlib 2.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+
+upload_channels:
+- sk_test
+channels:
+- sk_test
+upload_without_merge: True
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - requests >=2.0.0
   run_constrained:
     # oathlib[signedtoken] is taken from https://github.com/oauthlib/oauthlib/blob/v3.2.2/setup.py#L20
-    - ryptography >=3.0.0
+    - cryptography >=3.0.0
     - pyjwt >=2.0.0,<3
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,44 +1,52 @@
 {% set name = "requests-oauthlib" %}
-{% set version = "1.3.0" %}
-{% set hash_type = "sha256" %}
-{% set hash_val = "b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a" %}
+{% set version = "2.0.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash_val }}
+  sha256: b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
 
 build:
-  noarch: python
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - python
     - pip
-    - oauthlib >=3.0.0
-    - requests >=2.0.0
+    - setuptools
+    - wheel
 
   run:
     - python
     - oauthlib >=3.0.0
     - requests >=2.0.0
+  run_constrained:
+    # oathlib[signedtoken] is taken from https://github.com/oauthlib/oauthlib/blob/v3.2.2/setup.py#L20
+    - ryptography >=3.0.0
+    - pyjwt >=2.0.0,<3
 
 test:
   imports:
     - requests_oauthlib
     - requests_oauthlib.compliance_fixes
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/requests/requests-oauthlib
   license: ISC
+  license_family: Other
   license_file: LICENSE
-  summary: 'OAuthlib authentication support for Requests.'
+  summary: OAuthlib authentication support for Requests.
+  description: |
+    Requests-OAuthlib uses the Python Requests and OAuthlib libraries
+    to provide an easy-to-use Python interface for building OAuth1 and OAuth2 clients.
   dev_url: https://github.com/requests/requests-oauthlib
   doc_url: https://github.com/requests/requests-oauthlib
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-2273](https://anaconda.atlassian.net/browse/PKG-2273)
- release-notes: https://github.com/requests/requests-oauthlib/releases
- release-diff: https://github.com/requests/requests-oauthlib/compare/v1.3.0...v2.0.0
- changelog: https://github.com/requests/requests-oauthlib/blob/master/HISTORY.rst
- license: https://github.com/requests/requests-oauthlib/blob/master/LICENSE
- requirements-tagged:
  - https://github.com/requests/requests-oauthlib/blob/v2.0.0/setup.py


### Explanation of changes:

- Remove noarch python
- Remove `oathlib` and `requests` from `host`
- Add `run_constrained` with `cryptography` and `pyjwt`, see https://github.com/oauthlib/oauthlib/blob/v3.2.2/setup.py#L20
- Add pip check
- Add description

[PKG-2273]: https://anaconda.atlassian.net/browse/PKG-2273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ