### PR TITLE
v2.0.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-
-upload_channels:
-- sk_test
-channels:
-- sk_test
-upload_without_merge: True
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -v
 
 requirements:
   host:


### PR DESCRIPTION
Remove abs.yaml with the staging channel. Instead of an unsuccessful build https://github.com/AnacondaRecipes/requests-oauthlib-feedstock/pull/3